### PR TITLE
Add one-time payment feature to MomoPay

### DIFF
--- a/lib/momo_pay.rb
+++ b/lib/momo_pay.rb
@@ -17,6 +17,8 @@ require "momo_pay/request"
 require "momo_pay/rsa"
 require "momo_pay/signature"
 require "momo_pay/transaction"
+require "momo_pay/one_time_payment"
+require "momo_pay/one_time_payment_signature"
 
 module MomoPay
 

--- a/lib/momo_pay/config.rb
+++ b/lib/momo_pay/config.rb
@@ -11,6 +11,7 @@ module MomoPay
     attr_accessor :verify_keys
     attr_accessor :signature_confirm_keys
     attr_accessor :signature_qr_code_keys
+    attr_accessor :signature_one_time_payment_keys
 
     def public_key_pem
       @public_key_pem ||= [
@@ -29,9 +30,11 @@ module MomoPay
     def initialize
       self.signature_confirm_keys = MomoPay::Default::SIGNATURE_CONFIRM_KEYS
       self.signature_qr_code_keys = MomoPay::Default::SIGNATURE_QR_CODE_KEYS
+      self.signature_one_time_payment_keys = MomoPay::Default::SIGNATURE_ONE_TIME_PAYMENT_KEYS
       self.verify_keys = {
         mobile: MomoPay::Default::SIGNATURE_MOBILE_VERIFY_KEYS,
         ipn: MomoPay::Default::SIGNATURE_IPN_VERIFY_KEYS,
+        one_time_payment: MomoPay::Default::SIGNATURE_ONE_TIME_PAYMENT_VERIFY_KEYS,
       }
     end
 

--- a/lib/momo_pay/default.rb
+++ b/lib/momo_pay/default.rb
@@ -45,5 +45,33 @@ module MomoPay
       'extraData',
     ]
 
+    SIGNATURE_ONE_TIME_PAYMENT_VERIFY_KEYS = [
+      'accessKey',
+      'amount',
+      'extraData',
+      'message',
+      'orderId',
+      'orderInfo',
+      'orderType',
+      'partnerCode',
+      'payType',
+      'requestId',
+      'responseTime',
+      'resultCode',
+      'transId'
+    ]
+
+    SIGNATURE_ONE_TIME_PAYMENT_KEYS = [
+      'accessKey',
+      'amount',
+      'extraData',
+      'ipnUrl',
+      'orderId',
+      'orderInfo',
+      'partnerCode',
+      'redirectUrl',
+      'requestId',
+      'requestType'
+    ]
   end
 end

--- a/lib/momo_pay/one_time_payment.rb
+++ b/lib/momo_pay/one_time_payment.rb
@@ -1,0 +1,18 @@
+module MomoPay
+  class OneTimePayment
+
+    def self.request(data)
+      data.merge!({
+        requestType: 'captureWallet',
+        accessKey: MomoPay.setup.access_key,
+        partnerCode: MomoPay.setup.partner_code,
+        partnerName: MomoPay.setup.partner_name,
+      })
+      signature = MomoPay::Signature.new(data, MomoPay.setup.signature_one_time_payment_keys).to_s
+      data.merge!(signature: signature)
+
+      MomoPay::Request.post('/v2/gateway/api/create', data)
+    end
+
+  end
+end

--- a/lib/momo_pay/one_time_payment_signature.rb
+++ b/lib/momo_pay/one_time_payment_signature.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module MomoPay
+  class OneTimePaymentSignature < Signature
+
+    def initialize(data, keys)
+      data.merge!({
+        accessKey: MomoPay.setup.access_key,
+      })
+      @query_string = MomoPay::QueryString.new(data).to_s(keys)
+    end
+
+    def to_s
+      OpenSSL::HMAC.hexdigest("SHA256", MomoPay.setup.secret_key, query_string)
+    end
+
+    private
+
+    attr_reader :query_string
+
+  end
+end
+

--- a/lib/momo_pay/version.rb
+++ b/lib/momo_pay/version.rb
@@ -1,3 +1,3 @@
 module MomoPay
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end


### PR DESCRIPTION
This commit introduces support for one-time payments for the MomoPay library.

Key Changes:
- Extended the MomoPay module and added 'OneTimePayment' and 'OneTimePaymentSignature' classes.
- Integrated a method to make a one-time payment request in 'OneTimePayment' class.
- Added attributes for one-time payment-specific keys in 'config.rb'.
- Introduced new constants in 'Default' for one-time payment signature and verification keys.

These changes brought two primary benefits:
1. Users are now provided the flexibility to make one-time payments.
2. The added security features provided by the 'OneTimePaymentSignature' class ensures that transactions are authenticated and securely processed.

The library version has been bumped to reflect these changes.